### PR TITLE
update timescale documentation links

### DIFF
--- a/timescaledb/README.md
+++ b/timescaledb/README.md
@@ -41,7 +41,7 @@ Databases not in this list will act like normal Postgre databases.
 
 Switches the telemetry of TimescaleDb on or off.
 Valid options are: 'basic' or 'off'.
-See: https://docs.timescale.com/latest/using-timescaledb/telemetry
+See: https://www.tigerdata.com/docs/self-hosted/latest/configuration/telemetry
 
 #### Option: `timescaledb.maxmemory`
 
@@ -60,7 +60,7 @@ Example: `maxcpu="2"`
 Or leave empty for accepting auto-tune.
 
 See also:
-https://docs.timescale.com/latest/getting-started/configuring
+https://www.tigerdata.com/docs/self-hosted/latest/configuration/about-configuration
 for further tuning. Your Postgres.config file is located in the addon's data directory.
 
 #### Option: `max_connections`


### PR DESCRIPTION
# Proposed Changes

Update links as docs.timescale.com was changed to https://www.tigerdata.com/ docs (legacy links giving 404 errors)

## Related Issues

https://github.com/expaso/hassos-addons/issues/53

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
